### PR TITLE
fix: update Node.js version to 22 for semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Hotfix for release workflow.

## Problem
Release workflow failed because semantic-release requires Node.js 22+ but workflow was using Node 20.

## Solution
Updated .github/workflows/release.yml to use Node.js 22.

## Testing
Next push to master will trigger release workflow with Node 22.